### PR TITLE
Add flask-restx, topic controller and router

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Topic Trainer is a web application designed to help users test and enhance their
 
 ## Table of Contents
 
+- [Database Schema](#database-schema)
 - [Installation](#installation)
+- [Additional Commands](#additional-commands)
 
 
 ## Database Schema
@@ -69,7 +71,9 @@ with the flask development server and will load the changes in real time.
    make migrate
    ```
    
-7. Open your browser and navigate to [**Topic Trainer**](http://flask.test)
+7. Open your browser and navigate to [**Topic Trainer**](http://flask.test:5000/api/doc) to see the API documentation.
+
+Documentation of the API is available on a swagger UI page.
 
 ## Additional Commands
 

--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ load_dotenv()
 app = create_app()
 
 if app_env != production:
+    from flask_cors import CORS
+    CORS(app)
     app.run(debug=True, host='0.0.0.0')
 
 application = app

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,7 +4,7 @@ events {
 
 http {
     server {
-        listen 81;
+        listen 5000;
         server_name flask.test;
 
         location / {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@ psycopg2-binary==2.9.7
 alembic==1.12.0
 python-dateutil==2.8.2
 Cerberus==1.3.5
+flask-restx==1.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,1 +1,2 @@
 pylint==2.17.5
+Flask-Cors==4.0.0

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+from src.api.api import create_api

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -1,0 +1,45 @@
+from flask_restx import Api, Resource, Namespace
+from src.api.models.topic import topic_output_schema
+from src.controllers import TopicController
+
+
+def create_api(app):
+    """
+    Create a Flask Restx API using the app factory pattern.
+    :param app: Flask app
+    :return: None
+    """
+
+    api = Api(
+        app,
+        title='Topic Trainer API',
+        description='API to manage topics, questions and answers ',
+        doc='/api/doc/',
+        version='0.1a'
+    )
+
+    app.config['RESTX_MASK_SWAGGER'] = False
+
+    topic_namespace = Namespace('topic', description='Topic related operations', path='/api/topic')
+    topic_model = api.model('Topic', topic_output_schema)
+
+    class Topic(Resource):
+        """
+        Topic resource methods
+        """
+        @api.doc(id='get_topics',
+                 description='Get all topics',
+                 responses={200: 'Success', 400: 'Bad Request'})
+        @api.marshal_with(topic_model)
+        def get(self):
+            """
+            Read operation for topic resource
+            Gets all topics
+            :return: List of topics
+            """
+            topic_controller = TopicController()
+            response = topic_controller.get_all_topics()
+            return response, 200
+
+    topic_namespace.add_resource(Topic, '/')
+    api.add_namespace(topic_namespace)

--- a/src/api/models/topic.py
+++ b/src/api/models/topic.py
@@ -1,0 +1,12 @@
+from flask_restx import fields
+
+topic_output_schema = {
+    'id': fields.String(required=True, description='Topic id'),
+    'technology': fields.String(required=True, description='Technology name', max_length=255),
+    'name': fields.String(required=True, description='Topic name', max_length=255),
+    'description': fields.String(required=True, description='Topic description', max_length=255),
+    'difficulty': fields.String(required=True, description='Topic difficulty',
+                                enum=['easy', 'medium', 'hard']),
+    'logoUrl': fields.String(attribute='logo_url', required=True,
+                             description='Topic logo url', max_length=255),
+}

--- a/src/app.py
+++ b/src/app.py
@@ -1,17 +1,18 @@
 from flask import Flask
+from src.router import router
+from src.api import create_api
 
 
-def create_app():
+def create_app() -> Flask:
     """
     Create a Flask app using the app factory pattern.
-
+    Pass the app to the router function to register routes.
+    Pass the app to the create_api function to register the API.
     :return: Flask app
     """
 
     app = Flask(__name__)
-
-    @app.route('/')
-    def index():
-        return 'Index'
+    router(app)
+    create_api(app)
 
     return app

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,0 +1,1 @@
+from src.controllers.topic import TopicController

--- a/src/controllers/topic.py
+++ b/src/controllers/topic.py
@@ -1,0 +1,51 @@
+# pylint: disable=too-few-public-methods
+from src.database.models import Topic
+from src.database.repositories import TopicRepository
+
+
+class TopicUtils:
+    """
+    Utility class for Topic related operations
+    """
+
+    @staticmethod
+    def build_logo_url(topic: dict) -> str or None:
+        """
+        Build logo url from topic technology
+        :param topic: dict
+        :return: str or None
+        """
+        topic_technology = topic.get('technology')
+        topic_url = None
+        if topic_technology:
+            topic_url = f"/logos/{topic_technology.lower()}.svg"
+        return topic_url
+
+    @staticmethod
+    def topic_adapter(topic: Topic) -> dict:
+        """
+        Adapter to modify topics to be sent to the client
+        :param topic: Topic
+        :return: dict
+        """
+        topic_dict = topic.to_dict()
+        topic_dict.update({'logo_url': TopicUtils.build_logo_url(topic_dict)})
+        return topic_dict
+
+
+class TopicController:
+    """
+    Controller to manage the operations needed to
+    interact with the Topic model and the client.
+    """
+    def __init__(self) -> None:
+        self.topic_repository = TopicRepository()
+
+    def get_all_topics(self) -> list[dict]:
+        """
+        Retrieve all topics in the client format
+        :return: list[dict]
+        """
+        topics = self.topic_repository.get_all()
+        response = [TopicUtils.topic_adapter(topic) for topic in topics]
+        return response

--- a/src/router.py
+++ b/src/router.py
@@ -1,0 +1,16 @@
+from flask import make_response, jsonify, request, send_from_directory
+
+
+def router(app):
+    """
+    Register routes for the Flask app.
+
+    :param app: Flask app
+    :return: None
+    """
+
+    @app.route('/logos/<path:path>', methods=['GET'])
+    def logos(path):
+        if request.method != 'GET':
+            return make_response(jsonify({'message': 'Method not allowed!'}), 405)
+        return send_from_directory('assets/logos', path)


### PR DESCRIPTION
- Add flask-restx for api functionality and documentation
- Add documentation for API on `/api/doc`
- Add topic controller to send topic data on client requests
- Update readme
- Add resource model for topic 
- Change nginx proxy port for 5000
- Add router for logo image serving
- Add CORS for development